### PR TITLE
bersagli highlighting implementation

### DIFF
--- a/app/src/androidTestvalutazionedanno/java/it/geosolutions/android/siigmobile/BersagliHighlightingTest.java
+++ b/app/src/androidTestvalutazionedanno/java/it/geosolutions/android/siigmobile/BersagliHighlightingTest.java
@@ -1,0 +1,173 @@
+package it.geosolutions.android.siigmobile;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.test.ActivityUnitTestCase;
+import android.util.Log;
+
+import com.squareup.okhttp.Headers;
+
+import org.mapsforge.core.model.BoundingBox;
+import org.mapsforge.core.model.GeoPoint;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Locale;
+
+import it.geosolutions.android.map.utils.ProjectionUtils;
+import it.geosolutions.android.map.wms.WMSLayer;
+import it.geosolutions.android.map.wms.WMSLayerChunker;
+import it.geosolutions.android.map.wms.WMSRequest;
+import it.geosolutions.android.map.wms.WMSSource;
+import it.geosolutions.android.siigmobile.spatialite.SpatialiteUtils;
+import it.geosolutions.android.siigmobile.wps.ValutazioneDannoWPSRequest;
+
+/**
+ * Created by Robert Oehler on 24.09.15.
+ *
+ */
+public class BersagliHighlightingTest extends ActivityUnitTestCase<MainActivity> {
+
+    public BersagliHighlightingTest() {
+        super(MainActivity.class);
+    }
+
+
+    public void testWMSResultLayer(){
+
+        final Context context = getInstrumentation().getTargetContext();
+
+        assertNotNull(context);
+
+        WMSSource destinationSource = new WMSSource(Config.DESTINATION_WMS_URL);
+
+        // Authorization Headers
+        Headers.Builder hbuilder = new Headers.Builder();
+        hbuilder.add("Authorization", Config.DESTINATION_AUTHORIZATION);
+        destinationSource.setHeaders(hbuilder.build());
+
+        WMSLayer layer = new WMSLayer(destinationSource, Config.WMS_LAYERS[1]);
+
+        layer.setVisibility(true);
+        layer.setTiled(false);
+        //create base parameters
+        HashMap<String, String> baseParams = new HashMap<>();
+        baseParams.put("format", "image/png8");
+        baseParams.put("transparent", "true");
+
+        baseParams.put("ENV", Config.WMS_ENV[1]);
+        baseParams.put("RISKPANEL", Config.WMS_RISKPANEL[1]);
+        baseParams.put("DEFAULTENV", Config.WMS_DEFAULTENV[1]);
+
+        //create a cql filter and put it into the params
+
+        final int radius = 200;
+        final GeoPoint p = new GeoPoint(45.59950609926247,9.360421657562274);
+
+        BoundingBox bb = new BoundingBox(p.latitude, p.longitude, p.latitude, p.longitude);
+        final BoundingBox extended = Util.extend(bb, radius);
+
+        final String minX = String.format(Locale.US, "%f", extended.minLongitude);
+        final String minY = String.format(Locale.US, "%f", extended.minLatitude);
+        final String maxX = String.format(Locale.US, "%f", extended.maxLongitude);
+        final String maxY = String.format(Locale.US, "%f", extended.maxLatitude);
+
+        final String wktPolygon = String.format(Locale.US, "POLYGON ((%s %s, %s %s, %s %s, %s %s, %s %s))",
+                minX, minY,
+                maxX, minY,
+                maxX, maxY,
+                minX, maxY,
+                minX, minY);
+
+        final String convertedPolygon = SpatialiteUtils.convertWGS84PolygonTo(context, wktPolygon, ValutazioneDannoWPSRequest.DAMAGE_AREA_EPSG);
+
+        final String filter = String.format(Locale.US, "INTERSECTS(geometria,%s)", convertedPolygon);
+
+        baseParams.put(WMSRequest.PARAMS.CQL_FILTER, filter);
+        baseParams.put(WMSRequest.PARAMS.MIN_ZOOM, String.valueOf(Config.WMS_BERSAGLI_HIGHLIGHT_MIN_ZOOM));
+
+        layer.setBaseParams(baseParams);
+
+        ArrayList<WMSLayer> layers = new ArrayList<>();
+
+        layers.add(layer);
+
+        //simulate the handling of the wms rendering pipeline
+
+        ArrayList<WMSRequest> requests = WMSLayerChunker.createChunkedRequests(layers);
+
+        assertNotNull(requests);
+
+        assertTrue(requests.size() > 0);
+
+        final int width = 1080;
+        final int height = 1347;
+        final BoundingBox boundingBox = new BoundingBox(45.579638312554735,9.33988094329834,45.620053811377424,9.386229515075684);
+
+        WMSRequest request = requests.get(0);
+
+        assertNotNull(request);
+
+        assertTrue(request.getMinZoom() == Config.WMS_BERSAGLI_HIGHLIGHT_MIN_ZOOM);
+
+        URL url = request.getURL(createParameters(width, height, boundingBox));
+
+        //connect
+        HttpURLConnection connection;
+        try {
+            connection = (HttpURLConnection) url.openConnection();
+            // Add Headers
+            if(request.getHeaders()!= null){
+                for(String n: request.getHeaders().names()) {
+                    connection.setRequestProperty(n, request.getHeaders().get(n));
+                }
+            }
+            connection.setConnectTimeout(1000);
+        } catch (IOException e2) {
+            Log.e("WMS", "error opening connection");
+            fail();
+            return;
+        }
+        InputStream is;
+        try {
+            is = connection.getInputStream();
+            Bitmap img = BitmapFactory.decodeStream(is);
+
+            assertNotNull(img);
+
+        } catch (IOException e1) {
+            fail();
+        }
+    }
+
+
+    private HashMap<String,String> createParameters(final int width, final int height, BoundingBox boundingBox){
+
+        double n = boundingBox.maxLatitude;
+        double w = boundingBox.minLongitude;
+        double s = boundingBox.minLatitude;
+        double e = boundingBox.maxLongitude;
+        double nm = ProjectionUtils.toWebMercatorY(n);
+        double wm = ProjectionUtils.toWebMercatorX(w);
+        double sm =ProjectionUtils.toWebMercatorY(s);
+        double em = ProjectionUtils.toWebMercatorX(e);
+        HashMap<String,String> params = new HashMap<>();
+
+        params.put("width",(width)+"");
+        params.put("height",(height)+"");
+
+        params.put("bbox", wm + "," + sm + "," + em + "," + nm);
+        params.put("service","WMS");
+        params.put("srs","EPSG:900913");
+        params.put("request","GetMap");
+        params.put("version","1.1.1");
+
+        return params;
+
+    }
+}

--- a/app/src/androidTestvalutazionedanno/java/it/geosolutions/android/siigmobile/ValutazioneDannoWPSTest.java
+++ b/app/src/androidTestvalutazionedanno/java/it/geosolutions/android/siigmobile/ValutazioneDannoWPSTest.java
@@ -63,7 +63,6 @@ public class ValutazioneDannoWPSTest extends ActivityUnitTestCase<ComputeFormAct
 
         final ValutazioneDannoWPSRequest request = new ValutazioneDannoWPSRequest(
                 features,
-                bufferWidth,
                 materials,
                 accident,
                 entities);

--- a/app/src/main/java/it/geosolutions/android/siigmobile/mapcontrol/FixedShapeMapInfoControl.java
+++ b/app/src/main/java/it/geosolutions/android/siigmobile/mapcontrol/FixedShapeMapInfoControl.java
@@ -230,8 +230,8 @@ public class FixedShapeMapInfoControl extends MapControl {
             @Override
             protected void infoDialogCircle(double x, double y, double radius, byte zoomLevel) {
 
-                if (mif.getSelectionCallback() != null && mif.getSelectionCallback() instanceof  CircleCreatedCallback) {
-                    ((CircleCreatedCallback)mif.getSelectionCallback()).circleCreated(y, x, radius, zoomLevel);
+                if (mif.getSelectionCallback() != null && mif.getSelectionCallback() instanceof CircleCreatedCallback) {
+                    ((CircleCreatedCallback) mif.getSelectionCallback()).circleCreated(y, x, radius, zoomLevel);
                 }
             }
         });
@@ -418,7 +418,9 @@ public class FixedShapeMapInfoControl extends MapControl {
             Log.v("MapInfoControl", "resultCode:"+resultCode);
         }
         disable();
-        getActivationButton().setSelected(false);
+        if(getActivationButton() != null) {
+            getActivationButton().setSelected(false);
+        }
         loadStyleSelectorPreferences();
         instantiateListener();
         setMode(mode);

--- a/app/src/valutazionedanno/java/it/geosolutions/android/siigmobile/Config.java
+++ b/app/src/valutazionedanno/java/it/geosolutions/android/siigmobile/Config.java
@@ -122,5 +122,7 @@ public class Config {
     public final static String WMS_GETINFO_PARAMETER_FEATURE_COUNT = "FEATURE_COUNT";
     public final static String WMS_GETINFO_PARAMETER_FORMAT = "FORMAT";
 
+    public static byte WMS_BERSAGLI_HIGHLIGHT_MIN_ZOOM = 14;
+
 
 }

--- a/app/src/valutazionedanno/java/it/geosolutions/android/siigmobile/MainActivity.java
+++ b/app/src/valutazionedanno/java/it/geosolutions/android/siigmobile/MainActivity.java
@@ -71,6 +71,7 @@ import it.geosolutions.android.map.utils.ZipFileManager;
 import it.geosolutions.android.map.view.AdvancedMapView;
 import it.geosolutions.android.map.wms.GetFeatureInfoConfiguration;
 import it.geosolutions.android.map.wms.WMSLayer;
+import it.geosolutions.android.map.wms.WMSRequest;
 import it.geosolutions.android.map.wms.WMSSource;
 import it.geosolutions.android.siigmobile.elaboration.ElaborationResult;
 import it.geosolutions.android.siigmobile.geocoding.GeoCodingSearchView;
@@ -81,6 +82,7 @@ import it.geosolutions.android.siigmobile.legend.LegendAdapter;
 import it.geosolutions.android.siigmobile.mapcontrol.FixedShapeMapInfoControl;
 import it.geosolutions.android.siigmobile.spatialite.DeleteUnsavedResultsTask;
 import it.geosolutions.android.siigmobile.spatialite.SpatialiteUtils;
+import it.geosolutions.android.siigmobile.wps.ValutazioneDannoWPSRequest;
 
 public class MainActivity extends MapActivityBase
         implements NavigationDrawerFragment.NavigationDrawerCallbacks {
@@ -137,6 +139,8 @@ public class MainActivity extends MapActivityBase
 
     private GetFeatureInfoConfiguration getFeatureInfoConfiguration;
 
+    private boolean showWMSHighlight = false;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -182,6 +186,8 @@ public class MainActivity extends MapActivityBase
 
                     clearMenu();
                     currentStyle = Config.DEFAULT_STYLE;
+
+                    showWMSHighlight = false;
 
                     loadDBLayers(null);
                     return true;
@@ -430,7 +436,7 @@ public class MainActivity extends MapActivityBase
 
         ArrayList<Layer> layers = new ArrayList<>();
 
-        if (layerToCenter == null || currentStyle == 0) { //wms mode
+        if (layerToCenter == null || currentStyle == 0 || (showWMSHighlight && elaborationResult != null)) { //wms mode
 
             if (mapInfoSelectionMode != MapInfoSelectionMode.GetFeatureInfo) {
                 mapInfoSelectionMode = MapInfoSelectionMode.GetFeatureInfo;
@@ -469,6 +475,38 @@ public class MainActivity extends MapActivityBase
                 baseParams.put("RISKPANEL", Config.WMS_RISKPANEL[(currentStyle >= Config.WMS_RISKPANEL.length ? Config.DEFAULT_STYLE : currentStyle)]);
                 baseParams.put("DEFAULTENV", Config.WMS_DEFAULTENV[(currentStyle >= Config.WMS_DEFAULTENV.length ? Config.DEFAULT_STYLE : currentStyle)]);
             }
+
+            if(showWMSHighlight){
+
+                //create a cql filter and put it into the params
+
+                final int radius = elaborationResult.getRadius();
+                final GeoPoint p = elaborationResult.getLocation();
+
+                BoundingBox bb = new BoundingBox(p.latitude, p.longitude, p.latitude, p.longitude);
+                final BoundingBox extended = Util.extend(bb, radius);
+
+                final String minX = String.format(Locale.US, "%f", extended.minLongitude);
+                final String minY = String.format(Locale.US, "%f", extended.minLatitude);
+                final String maxX = String.format(Locale.US, "%f", extended.maxLongitude);
+                final String maxY = String.format(Locale.US, "%f", extended.maxLatitude);
+
+                final String wktPolygon = String.format(Locale.US, "POLYGON ((%s %s, %s %s, %s %s, %s %s, %s %s))",
+                        minX, minY,
+                        maxX, minY,
+                        maxX, maxY,
+                        minX, maxY,
+                        minX, minY);
+
+                final String convertedPolygon = SpatialiteUtils.convertWGS84PolygonTo(getBaseContext(), wktPolygon, ValutazioneDannoWPSRequest.DAMAGE_AREA_EPSG);
+
+                final String filter = String.format(Locale.US, "INTERSECTS(geometria,%s)", convertedPolygon);
+
+                baseParams.put(WMSRequest.PARAMS.CQL_FILTER,filter);
+                baseParams.put(WMSRequest.PARAMS.MIN_ZOOM, String.valueOf(Config.WMS_BERSAGLI_HIGHLIGHT_MIN_ZOOM));
+            }
+
+
             layer.setBaseParams(baseParams);
 
             layers.add(layer);
@@ -1040,6 +1078,8 @@ public class MainActivity extends MapActivityBase
     public void applyResult(ElaborationResult result){
 
         elaborationResult = result;
+
+        showWMSHighlight = true;
 
         loadDBLayers(result.getResultTableName());
         invalidateMenu(result.getResultTableName(),  true);

--- a/map/src/main/java/it/geosolutions/android/map/listeners/OneTapListener.java
+++ b/map/src/main/java/it/geosolutions/android/map/listeners/OneTapListener.java
@@ -101,7 +101,7 @@ public class OneTapListener implements OnTouchListener, OnGestureListener {
 		double lon,lat, radius;
 		lon = ConversionUtilities.convertFromPixelsToLongitude(view, startX);
 		lat = ConversionUtilities.convertFromPixelsToLatitude(view, startY);
-		
+
 		//Calculate radius of one point selection
         float radius_pixel = (float)pref.getInt("OnePointSelectionRadius", 10);
         double fin_x = ConversionUtilities.convertFromPixelsToLongitude(view, startX+radius_pixel); 

--- a/map/src/main/java/it/geosolutions/android/map/wms/WMSRequest.java
+++ b/map/src/main/java/it/geosolutions/android/map/wms/WMSRequest.java
@@ -49,9 +49,12 @@ public class WMSRequest {
 		public static final String STYLES = "styles";
 		public static final String CQL_FILTER = "cql_filter";
 		public static final String LAYERS = "layers";
+		public static final String MIN_ZOOM= "min_zoom";
 	}
 
     private Headers headers;
+
+    private byte minZoom = 0;
 
 	/**
 	 * create a request for the WMS source and
@@ -149,14 +152,20 @@ public class WMSRequest {
 			if(bp != null){
 				//Special management for style
 				concatenateParameter(PARAMS.STYLES,styleStringWriter, bp, last);
-				//special management for cql_filter
-				if(l.baseParams.containsKey(PARAMS.CQL_FILTER)){
-					//TODO skip it for now
-				}
+
 				//manage other paramters
 				for(String paramName : l.baseParams.keySet() ){
 					if(paramName == null) continue;
-					if(!PARAMS.STYLES.equalsIgnoreCase(paramName) && !PARAMS.CQL_FILTER.equalsIgnoreCase(paramName)){
+
+                    //if a min zoom is available, extract it here
+                    if(PARAMS.MIN_ZOOM.equalsIgnoreCase(paramName)){
+                        minZoom = Byte.parseByte(l.baseParams.get(paramName));
+                        //but do not add it to the currentParams
+                        continue;
+                    }
+
+                    //don't include styles
+					if(!PARAMS.STYLES.equalsIgnoreCase(paramName)){
 							currentParams.put(paramName.toLowerCase(), l.baseParams.get(paramName));
 					}
 				}
@@ -186,4 +195,8 @@ public class WMSRequest {
 			styleStringWriter.append(",");
 		}
 	}
+
+    public byte getMinZoom() {
+        return minZoom;
+    }
 }

--- a/map/src/main/java/it/geosolutions/android/map/wms/renderer/WMSUntiledRenderer.java
+++ b/map/src/main/java/it/geosolutions/android/map/wms/renderer/WMSUntiledRenderer.java
@@ -17,12 +17,13 @@
  */
 package it.geosolutions.android.map.wms.renderer;
 
-import it.geosolutions.android.map.R;
-import it.geosolutions.android.map.renderer.RenderingException;
-import it.geosolutions.android.map.utils.ProjectionUtils;
-import it.geosolutions.android.map.wms.WMSLayer;
-import it.geosolutions.android.map.wms.WMSLayerChunker;
-import it.geosolutions.android.map.wms.WMSRequest;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Canvas;
+import android.util.Log;
+
+import org.mapsforge.android.maps.Projection;
+import org.mapsforge.core.model.BoundingBox;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,13 +33,12 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashMap;
 
-import org.mapsforge.android.maps.Projection;
-import org.mapsforge.core.model.BoundingBox;
-
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import android.graphics.Canvas;
-import android.util.Log;
+import it.geosolutions.android.map.R;
+import it.geosolutions.android.map.renderer.RenderingException;
+import it.geosolutions.android.map.utils.ProjectionUtils;
+import it.geosolutions.android.map.wms.WMSLayer;
+import it.geosolutions.android.map.wms.WMSLayerChunker;
+import it.geosolutions.android.map.wms.WMSRequest;
 
 /**
  * A Simple renderer that draws maps  
@@ -73,6 +73,10 @@ public  class WMSUntiledRenderer implements WMSRenderer{
 	 * @throws RenderingException 
 	 */
 	private void draw(Canvas c, WMSRequest r, BoundingBox boundingBox, byte zoomLevel) throws RenderingException {
+
+        if (zoomLevel < r.getMinZoom()) {
+            return;
+        }
 
 		URL url = r.getURL(createParameters(c,boundingBox,zoomLevel));
 		if(url == null) return; //TODO notify


### PR DESCRIPTION
Implementation for #24 

Rebased on current master on 28.09.15

Contains another bugfix for FixedShapeMapInfoControl which may crash if you deselect a control which is not tied to a "activationbutton" programmatically.

Actually a cql filter is added a request for a WMS layer which consists in a polygon of the area of the result and the INTERSECTS operation. As priorly cql filters were deliberately excluded from wms requests some small changes in WMSRequest were necessary. Now the min zoom level parameter is excluded as it is only needed to skip requests if the request has a lower zoom level than the one set.
