### PR TITLE
Spatialite label rendering

### DIFF
--- a/DATA/styles/result_ambientale.style
+++ b/DATA/styles/result_ambientale.style
@@ -1,0 +1,85 @@
+{
+	"dashed": false,
+	"maxZoom": 30,
+	"minZoom": 9,
+	"textfield": "",
+	"strokecolor": "#000000",
+	"shape": "square",
+	"fillcolor": "red",
+	"name": "result_ambientale",
+	"order": 7,
+	"fillalpha": 0.3,
+	"size": 5.0,
+	"strokealpha": 1.0,
+	"enabled": 0,
+	"decimationFactor": 1.0E-5,
+	"textsize": 5.0,
+	"width": 18.0,
+	"rules": [{
+		"filter": {
+            "PropertyName": "thema_ambientale",
+            "LowerBoundary": 0,
+            "UpperBoundary": 2
+		},
+		"symbolizer": {
+			"dashed": false,
+			"textfield": "rischio1",
+			"title": "basso",
+			"textsize": 12.0,
+			"textstrokecolor": "#000000",
+			"textfillcolor": "#000000",
+			"strokecolor": "#14F200",
+			"shape": "square",
+			"fillcolor": "green",
+			"fillalpha": 0.3,
+			"size": 15.0,
+			"strokealpha": 1.0,
+			"width": 18.0,
+			"label_minZoom" : 15
+		}
+	},{
+		"filter": {
+            "PropertyName": "thema_ambientale",
+            "LowerBoundary": 2,
+            "UpperBoundary": 3
+		},
+		"symbolizer": {
+			"dashed": false,
+			"textfield": "rischio1",
+			"title": "medio",
+			"textsize": 12.0,
+			"textstrokecolor": "#000000",
+			"textfillcolor": "#000000",
+			"strokecolor": "#FFFB00",
+			"shape": "square",
+			"fillcolor": "yellow",
+			"fillalpha": 0.3,
+			"size": 15.0,
+			"strokealpha": 1.0,
+			"width": 18.0,
+			"label_minZoom" : 15
+		}
+	},{
+		"filter": {
+            "PropertyName": "thema_ambientale",
+            "LowerBoundary": 3,
+            "UpperBoundary": 10
+		},
+		"symbolizer": {
+			"dashed": false,
+			"textfield": "rischio1",
+			"title": "alto",
+			"textsize": 12.0,
+			"textstrokecolor": "#000000",
+			"textfillcolor": "#000000",
+			"strokecolor": "#FF0000",
+			"shape": "square",
+			"fillcolor": "red",
+			"fillalpha": 0.3,
+			"size": 15.0,
+			"strokealpha": 1.0,
+			"width": 18.0,
+			"label_minZoom" : 15
+		}
+	}]
+}

--- a/DATA/styles/result_sociale.style
+++ b/DATA/styles/result_sociale.style
@@ -1,0 +1,85 @@
+{
+	"dashed": false,
+	"maxZoom": 30,
+	"minZoom": 9,
+	"textfield": "",
+	"strokecolor": "#000000",
+	"shape": "square",
+	"fillcolor": "red",
+	"name": "result_sociale",
+	"order": 7,
+	"fillalpha": 0.3,
+	"size": 5.0,
+	"strokealpha": 1.0,
+	"enabled": 0,
+	"decimationFactor": 1.0E-5,
+	"textsize": 5.0,
+	"width": 18.0,
+	"rules": [{
+		"filter": {
+            "PropertyName": "thema_sociale",
+            "LowerBoundary": 0,
+            "UpperBoundary": 2
+		},
+		"symbolizer": {
+			"dashed": false,
+			"textfield": "rischio1",
+			"title": "basso",
+			"textsize": 12.0,
+			"textstrokecolor": "#000000",
+			"textfillcolor": "#000000",
+			"strokecolor": "#14F200",
+			"shape": "square",
+			"fillcolor": "green",
+			"fillalpha": 0.3,
+			"size": 15.0,
+			"strokealpha": 1.0,
+			"width": 18.0,
+			"label_minZoom" : 15
+		}
+	},{
+		"filter": {
+            "PropertyName": "thema_sociale",
+            "LowerBoundary": 2,
+            "UpperBoundary": 3
+		},
+		"symbolizer": {
+			"dashed": false,
+			"textfield": "rischio1",
+			"title": "medio",
+			"textsize": 12.0,
+			"textstrokecolor": "#000000",
+			"textfillcolor": "#000000",
+			"strokecolor": "#FFFB00",
+			"shape": "square",
+			"fillcolor": "yellow",
+			"fillalpha": 0.3,
+			"size": 15.0,
+			"strokealpha": 1.0,
+			"width": 18.0,
+			"label_minZoom" : 15
+		}
+	},{
+		"filter": {
+            "PropertyName": "thema_sociale",
+            "LowerBoundary": 3,
+            "UpperBoundary": 10
+		},
+		"symbolizer": {
+			"dashed": false,
+			"textfield": "rischio1",
+			"title": "alto",
+			"textsize": 12.0,
+			"textstrokecolor": "#000000",
+			"textfillcolor": "#000000",
+			"strokecolor": "#FF0000",
+			"shape": "square",
+			"fillcolor": "red",
+			"fillalpha": 0.3,
+			"size": 15.0,
+			"strokealpha": 1.0,
+			"width": 18.0,
+			"label_minZoom" : 15
+		}
+	}]
+}

--- a/DATA/styles/result_totale.style
+++ b/DATA/styles/result_totale.style
@@ -1,0 +1,217 @@
+{
+	"dashed": false,
+	"maxZoom": 30,
+	"minZoom": 9,
+	"textfield": "",
+	"strokecolor": "#000000",
+	"shape": "square",
+	"fillcolor": "red",
+	"name": "result_totale",
+	"order": 7,
+	"fillalpha": 0.3,
+	"size": 5.0,
+	"strokealpha": 1.0,
+	"enabled": 0,
+	"decimationFactor": 1.0E-5,
+	"textsize": 5.0,
+	"width": 18.0,
+	"rules": [{
+		"filter": {
+            "PropertyName": "thema_totale",
+            "LowerBoundary": 0,
+            "UpperBoundary": 2
+		},
+		"symbolizer": {
+			"dashed": false,
+			"textfield": "rischio1",
+			"title": "basso - basso",
+			"textsize": 12.0,
+			"textstrokecolor": "#000000",
+			"textfillcolor": "#000000",
+			"strokecolor": "#14F200",
+			"shape": "square",
+			"fillcolor": "#14F200",
+			"fillalpha": 0.3,
+			"size": 15.0,
+			"strokealpha": 1.0,
+			"width": 18.0,
+			"label_minZoom" : 15
+		}
+	},{
+		"filter": {
+            "PropertyName": "thema_totale",
+            "LowerBoundary": 2,
+            "UpperBoundary": 3
+		},
+		"symbolizer": {
+			"dashed": false,
+			"textfield": "rischio1",
+			"title": "basso - medio",
+			"textsize": 12.0,
+			"textstrokecolor": "#000000",
+			"textfillcolor": "#000000",
+			"strokecolor": "#0A7900",
+			"shape": "square",
+			"fillcolor": "#0A7900",
+			"fillalpha": 0.3,
+			"size": 15.0,
+			"strokealpha": 1.0,
+			"width": 18.0,
+			"label_minZoom" : 15
+		}
+	},{
+		"filter": {
+            "PropertyName": "thema_totale",
+            "LowerBoundary": 3,
+            "UpperBoundary": 4
+		},
+		"symbolizer": {
+			"dashed": false,
+			"textfield": "rischio1",
+			"title": "basso - alto",
+			"textsize": 12.0,
+			"textstrokecolor": "#000000",
+			"textfillcolor": "#000000",
+			"strokecolor": "#053800",
+			"shape": "square",
+			"fillcolor": "#053800",
+			"fillalpha": 0.3,
+			"size": 15.0,
+			"strokealpha": 1.0,
+			"width": 18.0,
+			"label_minZoom" : 15
+		}
+	},{
+		"filter": {
+            "PropertyName": "thema_totale",
+            "LowerBoundary": 4,
+            "UpperBoundary": 5
+		},
+		"symbolizer": {
+			"dashed": false,
+			"textfield": "rischio1",
+			"title": "medio - basso",
+			"textsize": 12.0,
+			"textstrokecolor": "#000000",
+			"textfillcolor": "#000000",
+			"strokecolor": "#A5FB00",
+			"shape": "square",
+			"fillcolor": "#A5FB00",
+			"fillalpha": 0.3,
+			"size": 15.0,
+			"strokealpha": 1.0,
+			"width": 18.0,
+			"label_minZoom" : 15
+		}
+	},{
+		"filter": {
+            "PropertyName": "thema_totale",
+            "LowerBoundary": 5,
+            "UpperBoundary": 6
+		},
+		"symbolizer": {
+			"dashed": false,
+			"textfield": "rischio1",
+			"title": "medio - medio",
+			"textsize": 12.0,
+			"textstrokecolor": "#000000",
+			"textfillcolor": "#000000",
+			"strokecolor": "#FFFB00",
+			"shape": "square",
+			"fillcolor": "#FFFB00",
+			"fillalpha": 0.3,
+			"size": 15.0,
+			"strokealpha": 1.0,
+			"width": 18.0,
+			"label_minZoom" : 15
+		}
+	},{
+		"filter": {
+            "PropertyName": "thema_totale",
+            "LowerBoundary": 6,
+            "UpperBoundary": 7
+		},
+		"symbolizer": {
+			"dashed": false,
+			"textfield": "rischio1",
+			"title": "medio - alto",
+			"textsize": 12.0,
+			"textstrokecolor": "#000000",
+			"textfillcolor": "#000000",
+			"strokecolor": "#FF9800",
+			"shape": "square",
+			"fillcolor": "#FF9800",
+			"fillalpha": 0.3,
+			"size": 15.0,
+			"strokealpha": 1.0,
+			"width": 18.0,
+			"label_minZoom" : 15
+		}
+	},{
+		"filter": {
+            "PropertyName": "thema_totale",
+            "LowerBoundary": 7,
+            "UpperBoundary": 8
+		},
+		"symbolizer": {
+			"dashed": false,
+			"textfield": "rischio1",
+			"title": "alto - basso",
+			"textsize": 12.0,
+			"textstrokecolor": "#000000",
+			"textfillcolor": "#000000",
+			"strokecolor": "#FFB4B4",
+			"shape": "square",
+			"fillcolor": "#FFB4B4",
+			"fillalpha": 0.3,
+			"size": 15.0,
+			"strokealpha": 1.0,
+			"width": 18.0,
+			"label_minZoom" : 15
+		}
+	},{
+		"filter": {
+            "PropertyName": "thema_totale",
+            "LowerBoundary": 8,
+            "UpperBoundary": 9
+		},
+		"symbolizer": {
+			"dashed": false,
+			"textfield": "rischio1",
+			"title": "alto - medio",
+			"textsize": 12.0,
+			"textstrokecolor": "#000000",
+			"textfillcolor": "#000000",
+			"strokecolor": "#FF6A6A",
+			"shape": "square",
+			"fillcolor": "#FF6A6A",
+			"fillalpha": 0.3,
+			"size": 15.0,
+			"strokealpha": 1.0,
+			"width": 18.0,
+			"label_minZoom" : 15
+		}
+	},{
+		"filter": {
+            "PropertyName": "thema_totale",
+            "LowerBoundary": 9,
+            "UpperBoundary": 10
+		},
+		"symbolizer": {
+			"dashed": false,
+			"textfield": "rischio1",
+			"title": "alto - alto",
+			"textsize": 12.0,
+			"textstrokecolor": "#000000",
+			"textfillcolor": "#000000",
+			"strokecolor": "#FF0000",
+			"shape": "square",
+			"fillcolor": "red",
+			"fillalpha": 0.3,
+			"size": 15.0,
+			"strokealpha": 1.0,
+			"width": 18.0,
+			"label_minZoom" : 15
+		}
+	}]
+}

--- a/app/src/androidTestvalutazionedanno/java/it/geosolutions/android/siigmobile/SpatialiteLayerLabelRenderingTest.java
+++ b/app/src/androidTestvalutazionedanno/java/it/geosolutions/android/siigmobile/SpatialiteLayerLabelRenderingTest.java
@@ -1,0 +1,239 @@
+package it.geosolutions.android.siigmobile;
+
+import android.content.Context;
+import android.os.Environment;
+import android.test.ActivityUnitTestCase;
+import android.util.Log;
+import android.util.Pair;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
+
+import org.mapsforge.core.model.BoundingBox;
+import org.mapsforge.core.model.CoordinatesUtil;
+import org.mapsforge.core.model.GeoPoint;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import eu.geopaparazzi.spatialite.database.spatial.core.GeometryIterator;
+import eu.geopaparazzi.spatialite.database.spatial.core.SpatialVectorTable;
+import it.geosolutions.android.map.database.spatialite.SpatialiteDataSourceHandler;
+import it.geosolutions.android.map.spatialite.renderer.LabelGeometryIterator;
+import it.geosolutions.android.map.style.AdvancedStyle;
+import it.geosolutions.android.map.style.StyleManager;
+import it.geosolutions.android.map.utils.MapFilesProvider;
+import it.geosolutions.android.map.wfs.geojson.feature.Feature;
+import it.geosolutions.android.map.wfs.geojson.feature.FeatureCollection;
+import it.geosolutions.android.siigmobile.spatialite.SpatialiteUtils;
+import it.geosolutions.android.siigmobile.wps.CRSFeatureCollection;
+import it.geosolutions.android.siigmobile.wps.SIIGRetrofitClient;
+import it.geosolutions.android.siigmobile.wps.ValutazioneDannoWPSRequest;
+import jsqlite.*;
+
+/**
+ * Created by Robert Oehler on 28.09.15.
+ *
+ */
+public class SpatialiteLayerLabelRenderingTest extends ActivityUnitTestCase<ComputeFormActivity> {
+
+
+    public SpatialiteLayerLabelRenderingTest() {
+        super(ComputeFormActivity.class);
+    }
+
+
+    /**
+     * tests the availability of data to render labels on spatialite layers
+     *
+     * this is done by
+     * 1.executing a wps request
+     * 2.creating a result table
+     * 3.iterating its content applying the current result_ambientale.style
+     * 4. reading out the column which is defined by "labelName" in the style
+     * 5. checking the availibility of this data
+     * and the result (test) table deleted
+     */
+    public void testLabelRendering(){
+
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        final Context context = getInstrumentation().getTargetContext();
+
+        assertNotNull(context);
+
+        //create a wps request
+        final String accident  = "10";
+        final String materials = Util.commaSeparatedListForDangers(context);
+        final String entities = Util.commaSeparatedListForEntities(context);
+
+        final int bufferWidth = 500;
+
+        final GeoPoint p = new GeoPoint(45.3134357, 9.507105);
+
+        CoordinatesUtil.validateLatitude(p.latitude);
+        CoordinatesUtil.validateLongitude(p.longitude);
+
+        BoundingBox bb = new BoundingBox(p.latitude, p.longitude, p.latitude, p.longitude);
+
+        BoundingBox extended = Util.extend(bb, bufferWidth);
+        final BoundingBox mapBB    = Util.extend(bb, 1500);
+
+        Coordinate[] coords = new Coordinate[2];
+        coords[0] = new Coordinate(extended.minLongitude, extended.minLatitude);
+        coords[1] = new Coordinate(extended.maxLongitude, extended.maxLatitude);
+
+        GeometryFactory fact = new GeometryFactory();
+        FeatureCollection features = new FeatureCollection();
+        features.features = new ArrayList<>();
+        Feature bbox = new Feature();
+        bbox.geometry = fact.createLineString(coords);
+        features.features.add(bbox);
+
+        final ValutazioneDannoWPSRequest request = new ValutazioneDannoWPSRequest(
+                features,
+                materials,
+                accident,
+                entities);
+
+        final String query  = request.createWPSCallFromText(getInstrumentation().getTargetContext()); //this adds additional parameters
+
+        SIIGRetrofitClient.postWPS(query, Config.DESTINATION_AUTHORIZATION, new SIIGRetrofitClient.WPSRequestFeedback() {
+            @Override
+            public void success(CRSFeatureCollection result) {
+
+                Log.i(getClass().getSimpleName(), " result successfully parsed");
+
+                assertNotNull(result);
+                assertTrue(result.features.size() > 0);
+
+                //persist the result
+                final Database db = SpatialiteUtils.openSpatialiteDB(context);
+                final String geomType = result.features.get(0).geometry.getGeometryType().toUpperCase();
+                final Pair<Boolean, String> resultPair = SpatialiteUtils.saveResult(db, result, geomType);
+
+                assertNotNull(resultPair);
+                assertTrue(resultPair.first);
+                final String resultTableName = resultPair.second;
+
+                //close the db to not interfere with spatialdatabasehandler
+                try {
+                    db.close();
+                } catch (jsqlite.Exception e) {
+                    Log.e(getClass().getSimpleName(), "error closing db", e);
+                }
+
+                try {
+                    //get the style
+                    MapFilesProvider.setBaseDir(Config.BASE_DIR_NAME);
+                    StyleManager styleManager = StyleManager.getInstance();
+                    final AdvancedStyle style = styleManager.getStyle(Config.RESULT_STYLES[0]);
+
+                    assertNotNull(style);
+                    assertTrue(style.rules.length > 0);
+
+                    //get the spatial db
+                    final String dbPath = Environment.getExternalStorageDirectory() + Config.BASE_DIR_NAME + "/" + SpatialiteUtils.DB_NAME;
+                    SpatialiteDataSourceHandler spatialDatabaseHandler = new SpatialiteDataSourceHandler(dbPath);
+
+                    //get the result table as SpatialVectorTable object
+                    SpatialVectorTable spatialTable = null;
+                    List<SpatialVectorTable> spatialTables = null;
+                    try {
+                        spatialTables = spatialDatabaseHandler.getSpatialVectorTables(false);
+                    } catch (jsqlite.Exception e) {
+                        Log.e(getClass().getSimpleName(), "error getting vector tables", e);
+                    }
+                    assertNotNull(spatialTables);
+                    for (SpatialVectorTable table : spatialTables) {
+                        if (table.getName().equals(resultTableName)) {
+                            spatialTable = table;
+                        }
+                    }
+                    assertNotNull(spatialTable);
+
+                    //get the label name of the symbolizer of the first rule
+                    final String labelName = style.rules[0].getSymbolizer().textfield;
+
+                    assertNotNull(labelName);
+                    //check that such a column exists
+                    assertTrue(spatialDatabaseHandler.checkIfColumnExists(spatialTable,labelName));
+                    //check also that some weird column not exists
+                    assertFalse(spatialDatabaseHandler.checkIfColumnExists(spatialTable,"dodo"));
+
+                    spatialDatabaseHandler.setAdditionalQueryColumn(labelName);
+
+                    //get a geometry iterator from result table
+                    GeometryIterator geometryIterator = spatialDatabaseHandler.getGeometryIteratorInBounds(
+                            "4326",
+                            spatialTable,
+                            mapBB.maxLatitude,
+                            mapBB.minLatitude,
+                            mapBB.maxLongitude,
+                            mapBB.minLongitude
+                    );
+
+                    // assert this is an iterator which reads label data
+                    assertNotNull(geometryIterator);
+                    assertTrue(geometryIterator instanceof LabelGeometryIterator);
+                    assertTrue(geometryIterator.hasNext());
+
+                    //simulate rendering --> read data
+                    while (geometryIterator.hasNext()) {
+
+                        Geometry geom = geometryIterator.next();
+                        assertNotNull(geom);
+
+                        //test that the additional column is read and available
+                        Object o = geom.getUserData();
+                        assertNotNull(o);
+
+                        //in this case we expect double values
+                        assertTrue(o instanceof Double);
+                    }
+
+                    Log.i(getClass().getSimpleName(), " objects successfully read");
+
+                    //done close
+                    try {
+                        spatialDatabaseHandler.close();
+                    } catch (jsqlite.Exception e1) {
+                        Log.e(getClass().getSimpleName(), "error closing db", e1);
+                    }
+                } finally {
+
+                    //delete the test table
+                    Database db2 = SpatialiteUtils.openSpatialiteDB(context);
+                    SpatialiteUtils.deleteResult(db2, resultTableName);
+
+                    try {
+                        db2.close();
+                    } catch (jsqlite.Exception e1) {
+                        Log.e(getClass().getSimpleName(), "error closing db", e1);
+                    }
+                }
+
+                latch.countDown();
+            }
+
+            @Override
+            public void error(String errorMessage) {
+
+                fail("error : " + errorMessage);
+
+            }
+        });
+
+        try {
+            //wait for completion
+            latch.await(30, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Log.e(getClass().getSimpleName(), "error awaiting latch", e);
+        }
+
+
+    }
+}

--- a/app/src/androidTestvalutazionedanno/java/it/geosolutions/android/siigmobile/ValutazioneDannoWPSTest.java
+++ b/app/src/androidTestvalutazionedanno/java/it/geosolutions/android/siigmobile/ValutazioneDannoWPSTest.java
@@ -63,7 +63,6 @@ public class ValutazioneDannoWPSTest extends ActivityUnitTestCase<ComputeFormAct
 
         final ValutazioneDannoWPSRequest request = new ValutazioneDannoWPSRequest(
                 features,
-                bufferWidth,
                 materials,
                 accident,
                 entities);

--- a/map/src/main/java/it/geosolutions/android/map/listeners/OneTapListener.java
+++ b/map/src/main/java/it/geosolutions/android/map/listeners/OneTapListener.java
@@ -104,7 +104,7 @@ public class OneTapListener implements OnTouchListener, OnGestureListener {
 		
 		//Calculate radius of one point selection
         float radius_pixel = (float)pref.getInt("OnePointSelectionRadius", 10);
-        double fin_x = ConversionUtilities.convertFromPixelsToLongitude(view, startX+radius_pixel); 
+        double fin_x = ConversionUtilities.convertFromPixelsToLongitude(view, startX+radius_pixel);
         radius = Math.abs(fin_x - lon);
         Log.v("MAPINFOTOOL", "circle: center (" + lon + "," + lat + ") radius " + radius);
     	infoDialogCircle(lon,lat,radius,view.getMapViewPosition().getZoomLevel());

--- a/map/src/main/java/it/geosolutions/android/map/overlay/SpatialiteOverlay.java
+++ b/map/src/main/java/it/geosolutions/android/map/overlay/SpatialiteOverlay.java
@@ -147,7 +147,7 @@ public  class SpatialiteOverlay implements Overlay,FreezableOverlay {
                             return;
                         }
                     } else if (spatialTable.isLine()) {
-                        shapes.drawLines(style4Table);
+                        shapes.drawLines(style4Table, drawZoomLevel);
                         if (isInterrupted() || sizeHasChanged()) {
                             // stop working
                             return;

--- a/map/src/main/java/it/geosolutions/android/map/spatialite/renderer/LabelGeometryIterator.java
+++ b/map/src/main/java/it/geosolutions/android/map/spatialite/renderer/LabelGeometryIterator.java
@@ -1,0 +1,74 @@
+package it.geosolutions.android.map.spatialite.renderer;
+
+import android.util.Log;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.WKBReader;
+
+import java.util.Iterator;
+
+import eu.geopaparazzi.spatialite.database.spatial.core.GeometryIterator;
+import jsqlite.Database;
+import jsqlite.Exception;
+import jsqlite.Stmt;
+
+/**
+ * Created by Robert Oehler on 25.09.15.
+ *
+ * This a copy of the original GeometryIterator class which additionally
+ * extracts a second column out of the database stmt (if available)
+ * it is added to the Geometry object as "userdata"
+ *
+ */
+public class LabelGeometryIterator extends GeometryIterator implements Iterator<Geometry>  {
+
+    protected WKBReader wkbReader = new WKBReader();
+    protected Stmt stmt;
+
+    public LabelGeometryIterator( Database database, String query ) {
+        super(database,query);
+        try {
+            stmt = database.prepare(query);
+        } catch (jsqlite.Exception e) {
+            Log.e(getClass().getSimpleName(), "exception prepare stmt", e);
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (stmt == null)
+            return false;
+        try {
+            return stmt.step();
+        } catch (Exception e) {
+            Log.e(getClass().getSimpleName(),"exception stmt step",e);
+            return false;
+        }
+    }
+
+    @Override
+    public Geometry next() {
+        if (stmt == null)
+            return null;
+        try {
+            byte[] geomBytes = stmt.column_bytes(0);
+            Geometry geometry = wkbReader.read(geomBytes);
+            if(stmt.column_count() > 1) {
+                Object o = stmt.column(1);
+                if(o != null){
+                    geometry.setUserData(o);
+                }
+            }
+            return geometry;
+        } catch (java.lang.Exception e) {
+            Log.e(getClass().getSimpleName(),"exception next",e);
+        }
+        return null;
+    }
+
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/map/src/main/java/it/geosolutions/android/map/spatialite/renderer/SpatialiteRenderer.java
+++ b/map/src/main/java/it/geosolutions/android/map/spatialite/renderer/SpatialiteRenderer.java
@@ -27,10 +27,13 @@ import it.geosolutions.android.map.spatialite.SpatialiteLayer;
 import it.geosolutions.android.map.style.AdvancedStyle;
 import it.geosolutions.android.map.style.Rule;
 import it.geosolutions.android.map.style.StyleManager;
+import it.geosolutions.android.map.style.Symbolizer;
 import it.geosolutions.android.map.utils.ProjectionUtils;
 import it.geosolutions.android.map.utils.StyleUtils;
 
 import java.util.ArrayList;
+import java.util.HashSet;
+
 import jsqlite.Exception;
 
 import org.mapsforge.android.maps.Projection;
@@ -38,6 +41,7 @@ import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.GeoPoint;
 import android.graphics.Canvas;
 import android.graphics.Paint;
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.vividsolutions.jts.android.PointTransformation;
@@ -82,8 +86,7 @@ public class SpatialiteRenderer implements OverlayRenderer<SpatialiteLayer> {
 		return layers;
 	}
 
-	private void drawFromSpatialite(Canvas canvas, BoundingBox boundingBox,
-			byte drawZoomLevel) {
+	private void drawFromSpatialite(Canvas canvas, BoundingBox boundingBox, byte drawZoomLevel) {
 
 		if( layers == null){
 			// nothing to draw
@@ -136,7 +139,15 @@ public class SpatialiteRenderer implements OverlayRenderer<SpatialiteLayer> {
 
                                 if (spatialDatabaseHandler instanceof SpatialiteDataSourceHandler) {
                                     ((SpatialiteDataSourceHandler) spatialDatabaseHandler).setFilter(r.getFilter());
+
+                                    if(r.getSymbolizer().textfield != null){
+                                        //check if this column exists
+                                        if(((SpatialiteDataSourceHandler) spatialDatabaseHandler).checkIfColumnExists(spatialTable, r.getSymbolizer().textfield)) {
+                                            ((SpatialiteDataSourceHandler) spatialDatabaseHandler).setAdditionalQueryColumn(r.getSymbolizer().textfield);
+                                        }
+                                    }
                                 }
+
 
                                 geometryIterator = spatialDatabaseHandler
                                         .getGeometryIteratorInBounds("4326", spatialTable,
@@ -151,7 +162,7 @@ public class SpatialiteRenderer implements OverlayRenderer<SpatialiteLayer> {
 									shapes.drawPolygons(r.getSymbolizer());
 
                                 } else if (spatialTable.isLine()) {
-                                    shapes.drawLines(r.getSymbolizer());
+                                    shapes.drawLines(r.getSymbolizer(), drawZoomLevel);
 
                                 } else if (spatialTable.isPoint()) {
                                     //shapes.drawPoints(fill, stroke);
@@ -192,7 +203,7 @@ public class SpatialiteRenderer implements OverlayRenderer<SpatialiteLayer> {
                                 shapes.drawPolygons(style4Table);
 
                             } else if (spatialTable.isLine()) {
-                                shapes.drawLines(style4Table);
+                                shapes.drawLines(style4Table, drawZoomLevel);
 
                             } else if (spatialTable.isPoint()) {
                                 shapes.drawPoints(fill, stroke);
@@ -208,7 +219,7 @@ public class SpatialiteRenderer implements OverlayRenderer<SpatialiteLayer> {
 				}
 			}
 		} catch (Exception e1) {
-			Log.e("SpatialiteRenderer","Exception while rendering spatialite data");
+			Log.e("SpatialiteRenderer", "Exception while rendering spatialite data");
 			Log.e("SpatialiteRenderer", e1.getLocalizedMessage(), e1);
 		}
 	}

--- a/map/src/main/java/it/geosolutions/android/map/style/AdvancedStyle.java
+++ b/map/src/main/java/it/geosolutions/android/map/style/AdvancedStyle.java
@@ -32,4 +32,5 @@ public class AdvancedStyle extends Style implements Serializable{
     public Rule[] rules = null;
     public String textstrokecolor = "";
     public String textfillcolor = "";
+    public int label_minZoom = 14;
 }

--- a/map/src/main/java/it/geosolutions/android/map/style/Symbolizer.java
+++ b/map/src/main/java/it/geosolutions/android/map/style/Symbolizer.java
@@ -18,4 +18,5 @@ public class Symbolizer {
     public String title = "";
     public boolean dashed = false;
     public float decimationFactor = 0.00001f;
+    public int label_minZoom = 14;
 }


### PR DESCRIPTION
Implementation for #23 

The rendering is managed from the result styles files, which define rules. Rules contain a filter and a symbolizer. The property "labelName" was added to the filter object to define which database label is additionally read to be used to render the labels.
The properties of the symbolizer "textSize" and "textStrokeColor" are used to set-up the rendering of the label.

The filter is added to a database query which results in a "GeometryIterator". This class is copied as "LabelGeometryIterator" to the map module and extends the original by reading also a second column of the query statement, if available. The data, wrapped as object, is added as the geometries "userdata" object and can be used during rendering. See map/src/main/java/it/geosolutions/android/map/overlay/Shapes.java
If the current zoom level is >= the minimum for spatialite label rendering, the data read from the database is rendered on the path using objects toString() method. 